### PR TITLE
Fixed #197

### DIFF
--- a/terraform/TEMPLATES/create.html
+++ b/terraform/TEMPLATES/create.html
@@ -110,8 +110,12 @@
             <input type="button" value="Apply" id="apply" class="btn" name="button" onclick="updateiFrame(this)">
             <input type="button" value="Reset" id="reset" class="btn" name="button" onclick="openModal('reset_modal')">
             <input type="button" value="Destroy" id="destroy" class="btn" onclick="openModal('destroy_modal')">
-            <input type="button" {% if not vm_deploy %} style="display:none";{% endif %} value="Visibility UI" id="vkaci" class="btn btn--wide" name="button" onclick="window.open('{{ vkaci_ui }}','_blank')">
-            <input type="button" {% if vm_deploy %} style="display:none";{% endif %} value="Download Manifests" id="manifest" class="btn btn--wide" name="button" onclick="window.open('static/manifests/manifests.zip','_blank')">
+            {% if vm_deploy and fabric_type != 'vxlan_evpn' %}
+               <input type="button" value="Visibility UI" id="vkaci" class="btn btn--wide" name="button" onclick="window.open('{{ vkaci_ui }}','_blank')">
+            {% endif %}
+            {% if not vm_deploy %}
+               <input type="button" value="Download Manifests" id="manifest" class="btn btn--wide" name="button" onclick="window.open('static/manifests/manifests.zip','_blank')">
+            {% endif %}
 
             <div class="modal modal--small hide" id="reset_modal">
                <div class="modal__dialog">
@@ -195,10 +199,10 @@
 <script>
    function updateiFrame(button) {
        if (button.value === 'Plan') {
-           document.getElementById('iframe').src = "{{ url_for("tf_plan") }}" + '?fabric_type=' + getUrlParameter('fabric_type')
+           document.getElementById('iframe').src = "{{ url_for("tf_plan") }}" + '?fabric_type=' + "{{ fabric_type }}"
        }
        if (button.value === 'Apply') {
-           document.getElementById('iframe').src = "{{ url_for("tf_apply") }}" + '?fabric_type=' + getUrlParameter('fabric_type')
+           document.getElementById('iframe').src = "{{ url_for("tf_apply") }}" + '?fabric_type=' + "{{ fabric_type }}"
        }
    }
    startAutoScroll();
@@ -207,7 +211,7 @@
 <script>
     $(document).ready(function () {
         $("#btn_update_config").click(function (e) {
-            var update_url = "{{ url_for("update_config")}}" + '?fabric_type=' + getUrlParameter('fabric_type');
+            var update_url = "{{ url_for("update_config")}}" + '?fabric_type=' + "{{ fabric_type }}";
             $.ajax({
                 url: update_url,  
                 dataType: 'json',
@@ -226,13 +230,13 @@
             });
         });
         $("#btn_reset_confirm").click(function (e) {
-         var reset_url = "{{ url_for("reset")}}" + '?fabric_type=' + getUrlParameter('fabric_type');
+         var reset_url = "{{ url_for("reset")}}" + '?fabric_type=' + "{{ fabric_type }}";
          $("#reset_modal").addClass('hide');
          $("#iframe").attr('src',reset_url);
 
      });
           $("#btn_destroy_confirm").click(function (e) {
-              var update_url = "{{ url_for("destroy")}}" + '?fabric_type=' + getUrlParameter('fabric_type');
+              var update_url = "{{ url_for("destroy")}}" + '?fabric_type=' + "{{ fabric_type }}";
               $("#destroy_modal").addClass('hide');
               $("#iframe").attr('src',update_url);
           });

--- a/terraform/appflask.py
+++ b/terraform/appflask.py
@@ -610,12 +610,12 @@ def create_tf_config(fabric_type):
 def create():
     '''Page that creates the cluster'''
     vkaci_ui = ""
-    fabric_type = get_fabric_type(request) 
+    fabric_type = get_fabric_type(request)
     if fabric_type not in VALID_FABRIC_TYPE:
         return redirect('/')
     if request.method == 'GET':
         config, vkaci_ui, vm_deploy = create_tf_config(fabric_type)
-        return render_template('create.html', config=config, vkaci_ui=vkaci_ui, vm_deploy=vm_deploy)
+        return render_template('create.html', fabric_type=fabric_type, config=config, vkaci_ui=vkaci_ui, vm_deploy=vm_deploy)
     if request.method == 'POST':
         req = request.form
         button = req.get("button")
@@ -813,6 +813,9 @@ def calico_nodes_view():
                 i += 1
         ipv4_cluster_subnet = None
         ipv6_cluster_subnet = None
+        hostnames = []
+        if calico_nodes is not None:
+            hostnames = [d['hostname'] for d in calico_nodes]
         if fabric_type == "aci":
             l3out = json.loads(getdotenv('l3out'))
             ipv4_cluster_subnet=l3out["ipv4_cluster_subnet"]
@@ -821,11 +824,11 @@ def calico_nodes_view():
             overlay = json.loads(getdotenv('overlay'))
             ipv4_cluster_subnet=overlay["node_sub"]
             ipv6_cluster_subnet=overlay["node_sub_v6"]
-        return render_template('calico_nodes.html', 
-                                ipv4_cluster_subnet=ipv4_cluster_subnet, 
-                                ipv6_cluster_subnet=ipv6_cluster_subnet, 
+        return render_template('calico_nodes.html',
+                                ipv4_cluster_subnet=ipv4_cluster_subnet,
+                                ipv6_cluster_subnet=ipv6_cluster_subnet,
                                 calico_nodes=json.dumps(calico_nodes, indent=4),
-                                hostnames =  [d['hostname'] for d in calico_nodes],
+                                hostnames = hostnames,
                                 manage_cluster=manage_cluster,
                                 fabric_type=fabric_type)
 

--- a/terraform/selenium/selenium_ui_testing_dev_ndfc_v4.py
+++ b/terraform/selenium/selenium_ui_testing_dev_ndfc_v4.py
@@ -5,9 +5,18 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
+from selenium.common.exceptions import NoSuchElementException
 import random
 import argparse
 from time import sleep
+
+def check_exits_by_id(driver, id):
+    '''Test check html element exists by id'''
+    try:
+        driver.find_element(By.ID, id)
+    except NoSuchElementException:
+        return False
+    return True
 
 
 def add_calico_ndoe(driver, hostname, ip, rack_id):
@@ -192,7 +201,13 @@ def cluster_network_page(driver):
 
     WebDriverWait(driver, 60).until(EC.url_changes(current_url))
 
-
+def create_page(driver):
+    '''test create page'''
+    current_url = driver.current_url
+    assert "fabric_type=vxlan_evpn" in current_url
+    assert "Create" in driver.title
+    assert check_exits_by_id(driver, "vkaci") is False
+    
 def main():
     chrome_options = Options()
     run_id = "{:05d}".format(random.randint(1, 10000))
@@ -221,6 +236,7 @@ def main():
     calico_node_page(driver, run_id)
     cluster_page(driver)
     cluster_network_page(driver)
+    create_page(driver)
     sleep(5)
     driver.quit()
 


### PR DESCRIPTION
1. Hide vkaci button from create page for NDFC

> - To hide the vkaci button for NDFC, using JS inside the jinja template isn't possible. What I have done instead is pass the variable fabric_type directly through flask. 
> - The fabric_type variable needed to be passed in the render template function for the create page. 
> - Instead of using JS function to find the query parameter for fabric type, I have now used the template variable in the create page which is more consistent.

2. Fixed defect when changing from No Vm deploy to Vm deploy

3. Added additional test to selenium.